### PR TITLE
Refactor tests to use pyam.testing

### DIFF
--- a/test_resultify.py
+++ b/test_resultify.py
@@ -1,7 +1,8 @@
-from datetime import date
 import pandas as pd
 import os
 import pytest
+from pyam import IamDataFrame
+from pyam.testing import assert_iamframe_equal
 from .resultify import extract_results, filter_var_cost, filter_fuel, filter_emission, filter_emission_tech, filter_ProdByTechAn, filter_final_energy, filter_capacity
 
 
@@ -13,7 +14,7 @@ class TestEmissions:
         input_data = pd.read_csv(filepath)
 
         emission = ['CO2']
-        actual = filter_emission(input_data, emission)
+        obs = IamDataFrame(filter_emission(input_data, emission))
 
         data = [
             ['AT', 'CO2', 2026, -7573.069442598169],
@@ -30,11 +31,11 @@ class TestEmissions:
             ["BG", 'CO2', 2032, 11041.957354265856],
         ]
 
-        expected = pd.DataFrame(data=data, columns=['REGION', 'EMISSION', 'YEAR', 'VALUE'])
+        exp = IamDataFrame(
+            pd.DataFrame(data=data, columns=['REGION', 'EMISSION', 'YEAR', 'VALUE'])
+        )
 
-        index = ['REGION', 'EMISSION', 'YEAR']
-
-        pd.testing.assert_frame_equal(actual.set_index(index), expected.set_index(index), check_index_type=False)
+        assert_iamframe_equal(obs, exp)
     
     def test_filter_tech_emission(self):
 

--- a/test_resultify.py
+++ b/test_resultify.py
@@ -6,6 +6,8 @@ from pyam.testing import assert_iamframe_equal
 from .resultify import extract_results, filter_var_cost, filter_fuel, filter_emission, filter_emission_tech, filter_ProdByTechAn, filter_final_energy, filter_capacity
 
 
+SCENARIO_ARGS = dict(model="foo", scenario="bar")
+DATA_COLS = ["REGION", "VARIABLE", "YEAR", "VALUE"]
 class TestEmissions:
 
     def test_filter_emission(self):
@@ -14,7 +16,8 @@ class TestEmissions:
         input_data = pd.read_csv(filepath)
 
         emission = ['CO2']
-        obs = IamDataFrame(filter_emission(input_data, emission))
+
+        obs = IamDataFrame(filter_emission(input_data, emission), **SCENARIO_ARGS, variable="EMISSION", unit="?")
 
         data = [
             ['AT', 'CO2', 2026, -7573.069442598169],
@@ -32,7 +35,7 @@ class TestEmissions:
         ]
 
         exp = IamDataFrame(
-            pd.DataFrame(data=data, columns=['REGION', 'EMISSION', 'YEAR', 'VALUE'])
+            pd.DataFrame(data=data, columns=DATA_COLS), unit="?", **SCENARIO_ARGS,
         )
 
         assert_iamframe_equal(obs, exp)


### PR DESCRIPTION
When running the tests locally (python 3.8), I got a number of dtype-errors on the value-column (observed: `object`,  expected: `float`).

To fix this issue, I suggest to refactor to the pyam testing module ([docs](https://pyam-iamc.readthedocs.io/en/stable/api/testing.html)), because this gets around the issue of having to set an index, fix the data types, or sort.

The first commit implements this change only for the first test, for illustration that this results in leaner, easier-to-read code - if you agree that this is a useful improvement, I'll also implement it for the other tests.