### PR TITLE
Add GitHub Actions workflow to run the tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install pytest
+      run: pip install pytest
+
     - name: Install dependencies
       run: pip install -r requirements.txt
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,38 @@
+# This workflow installs the requirements and runs the tests
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: pytest
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  pytest:
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        python-version:
+        - '3.10'
+
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} py${{ matrix.python-version }}
+  
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Test with pytest
+      run: pytest .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 matplotlib
 pandas
 pyam-iamc >= 1.0  # the pyam package is released on pypi under this name
--e git+https://github.com/openENTRANCE/openentrance.git@main#egg=openentrance


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run the tests automatically. The workflow is currently failing with the error below, see the full log [here](https://github.com/danielhuppmann/osemosys2iamc/runs/6432667223?check_suite_focus=true).

I think that this error arises because the implementation is not (yet) structured as a proper package.

```
______________________ ERROR collecting test_resultify.py ______________________
ImportError while importing test module '/home/runner/work/osemosys2iamc/osemosys2iamc/test_resultify.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test_resultify.py:5: in <module>
    from .resultify import extract_results, filter_var_cost, filter_fuel, filter_emission, filter_emission_tech, filter_ProdByTechAn, filter_final_energy, filter_capacity
E   ImportError: attempted relative import with no known parent package
```