### PR TITLE
Redirect IAMC-format documentation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ The most recent high-profile application of the IAMC format is the [AR6 Scenario
 hosting the scenario ensemble supporting the quantitative assessment
 in the contribution by Working Group III to the IPCC's Sixth Assessment Report (AR6).
 
-Please refer to the Horizon 2020 project [openENTRANCE](https://github.com/openENTRANCE/openentrance#data-format-structure)
-for more information about the format and its usage in that project.
+Please refer to the [documentation](https://docs.ece.iiasa.ac.at/iamc.html)
+for more information about the format and its usage across model comparison projects.
 
 ## Writing a configuration file
 


### PR DESCRIPTION
This PR changes the reference for more info about the IAMC format given that the openENTRANCE project has officially ended a year ago and the IIASA documentation will be more reliably updated in the future.